### PR TITLE
Improve intra-year significance table labeling

### DIFF
--- a/R/reporting.R
+++ b/R/reporting.R
@@ -3,53 +3,19 @@
 # ---------------------------------------------------------------------------- #
 
 # --- Ayudante para fusionar celdas ---
-merge_group_cells <- function(wb, sheet, df, grp_des, start_row, ref_df = NULL) {
+merge_group_cells <- function(wb, sheet, df, grp_des, start_row) {
   if (length(grp_des) == 0) return()
-  values_df <- ref_df %||% df
   for (col_idx in seq_along(grp_des)) {
-    col_name <- grp_des[col_idx]
-    if (!col_name %in% names(values_df) || !col_name %in% names(df)) next
-    runs <- rle(as.character(values_df[[col_name]]))
+    runs <- rle(as.character(df[[grp_des[col_idx]]]))
     run_lengths <- runs$lengths
     end_rows_r <- cumsum(run_lengths)
     start_rows_r <- end_rows_r - run_lengths + 1
     for (j in seq_along(run_lengths)) {
       if (run_lengths[j] > 1 && !grepl("Total", runs$values[j], ignore.case = TRUE)) {
-        merge_rows <- start_row:(start_row + nrow(df) - 1)
-        row_start <- merge_rows[start_rows_r[j]]
-        row_end <- merge_rows[end_rows_r[j]]
-        openxlsx::mergeCells(wb, sheet, cols = col_idx, rows = row_start:row_end)
+        merge_rows <- start_row:(start_row + run_lengths[j] - 1) + (start_rows_r[j] - 1)
+        openxlsx::mergeCells(wb, sheet, cols = col_idx, rows = merge_rows)
       }
     }
-  }
-}
-
-apply_significance_format <- function(wb, sheet, df, grp_cols, start_row, start_col, numeric_style) {
-  if (is.null(df) || nrow(df) == 0) return()
-  merge_reference <- attr(df, "_merge_reference")
-  merge_cols <- intersect(grp_cols, names(merge_reference %||% df))
-  if (length(merge_cols) > 0) {
-    merge_group_cells(
-      wb,
-      sheet,
-      df,
-      merge_cols,
-      start_row = start_row + 1,
-      ref_df = merge_reference %||% df
-    )
-  }
-  numeric_cols <- (start_col + 1):(start_col + ncol(df) - 1)
-  data_rows <- (start_row + 1):(start_row + nrow(df))
-  if (length(numeric_cols) > 0 && length(data_rows) > 0) {
-    openxlsx::addStyle(
-      wb,
-      sheet,
-      style = numeric_style,
-      rows = data_rows,
-      cols = numeric_cols,
-      gridExpand = TRUE,
-      stack = TRUE
-    )
   }
 }
 
@@ -238,22 +204,18 @@ generate_prop_report <- function(hojas_list, filename, var, des, sufijo, porcent
       for (sfx in names(tests_combo)) {
         test_df <- tests_combo[[sfx]]
         if (!is.null(test_df)) {
-          titulo_test <- paste0("Test entre categorías año: ", sfx)
+          titulo_test <- paste0("Test entre categor\u00edas a\u00f1o: ", sfx)
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
 
           write_clean_table(wb, hoja_nm, test_df, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df) + 3
         }
       }
@@ -261,46 +223,35 @@ generate_prop_report <- function(hojas_list, filename, var, des, sufijo, porcent
       if (length(sufijo) > 1) {
         test_df_last <- lista_tests$against_last_year[[combo]]
         if (!is.null(test_df_last)) {
-          titulo_test <- "Test contra último año:"
+          titulo_test <- "Test contra \u00faltimo a\u00f1o:"
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df_last) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_last, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_last,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_last) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_last))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df_last) + 3
         }
 
         test_df_nac <- lista_tests$against_national[[combo]]
         if (!is.null(test_df_nac)) {
-          titulo_test <- "Test contra estimación nacional:"
+          titulo_test <- "Test contra estimaci\u00f3n nacional:"
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df_nac) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_nac, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_nac,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_nac) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_nac))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
         }
       }
-
-
-
     }
   }
   openxlsx::saveWorkbook(wb, filename, overwrite = TRUE)
@@ -395,22 +346,18 @@ generate_mean_report <- function(hojas_list, filename, var, des, sufijo, decimal
       for (sfx in names(tests_combo)) {
         test_df <- tests_combo[[sfx]]
         if (!is.null(test_df)) {
-          titulo_test <- paste0("Test entre categorías año: ", sfx)
+          titulo_test <- paste0("Test entre categor\u00edas a\u00f1o: ", sfx)
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
 
           write_clean_table(wb, hoja_nm, test_df, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df) + 3
         }
       }
@@ -418,46 +365,35 @@ generate_mean_report <- function(hojas_list, filename, var, des, sufijo, decimal
       if (length(sufijo) > 1) {
         test_df_last <- lista_tests$against_last_year[[combo]]
         if (!is.null(test_df_last)) {
-          titulo_test <- "Test contra último año:"
+          titulo_test <- "Test contra \u00faltimo a\u00f1o:"
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df_last) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_last, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_last,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_last) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_last))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df_last) + 3
         }
 
         test_df_nac <- lista_tests$against_national[[combo]]
         if (!is.null(test_df_nac)) {
-          titulo_test <- "Test contra estimación nacional:"
+          titulo_test <- "Test contra estimaci\u00f3n nacional:"
           openxlsx::writeData(wb, hoja_nm, titulo_test, startRow = fila, startCol = col_inicio_tests)
           cols_to_merge <- col_inicio_tests:(col_inicio_tests + ncol(test_df_nac) - 1)
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_nac, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_nac,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_nac) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_nac))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
         }
       }
-
-
-
     }
   }
   openxlsx::saveWorkbook(wb, filename, overwrite = TRUE)
@@ -560,15 +496,11 @@ generate_total_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
 
           write_clean_table(wb, hoja_nm, test_df, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df) + 3
         }
       }
@@ -582,15 +514,11 @@ generate_total_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_last, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_last,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_last) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_last))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df_last) + 3
         }
 
@@ -602,20 +530,13 @@ generate_total_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_nac, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_nac,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_nac) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_nac))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
         }
       }
-
-
-
     }
   }
   openxlsx::saveWorkbook(wb, filename, overwrite = TRUE)
@@ -717,15 +638,11 @@ generate_ratio_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
 
           write_clean_table(wb, hoja_nm, test_df, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df) + 3
         }
       }
@@ -739,15 +656,11 @@ generate_ratio_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_last, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_last,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_last) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_last))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df_last) + 3
         }
 
@@ -759,20 +672,13 @@ generate_ratio_report <- function(hojas_list, filename, var, des, sufijo, decima
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_nac, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_nac,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_nac) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_nac))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
         }
       }
-
-
-
     }
   }
   openxlsx::saveWorkbook(wb, filename, overwrite = TRUE)
@@ -875,15 +781,11 @@ generate_quantile_report <- function(hojas_list, filename, var, des, sufijo, cua
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
 
           write_clean_table(wb, hoja_nm, test_df, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df) + 3
         }
       }
@@ -897,15 +799,11 @@ generate_quantile_report <- function(hojas_list, filename, var, des, sufijo, cua
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_last, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_last,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_last) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_last))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
           fila <- fila + nrow(test_df_last) + 3
         }
 
@@ -917,20 +815,13 @@ generate_quantile_report <- function(hojas_list, filename, var, des, sufijo, cua
           openxlsx::mergeCells(wb, hoja_nm, cols = cols_to_merge, rows = fila)
           openxlsx::addStyle(wb, hoja_nm, style = hdrStyle, rows = fila, cols = col_inicio_tests)
           write_clean_table(wb, hoja_nm, test_df_nac, startRow = fila + 1, startCol = col_inicio_tests)
-          apply_significance_format(
-            wb,
-            hoja_nm,
-            test_df_nac,
-            grp_des,
-            start_row = fila + 1,
-            start_col = col_inicio_tests,
-            numeric_style = testStyle
-          )
+          numeric_cols <- (col_inicio_tests + 1):(col_inicio_tests + ncol(test_df_nac) - 1)
+          data_rows <- (fila + 2):(fila + 1 + nrow(test_df_nac))
+          if(length(numeric_cols) > 0 && length(data_rows) > 0) {
+            openxlsx::addStyle(wb, hoja_nm, style = testStyle, rows = data_rows, cols = numeric_cols, gridExpand = TRUE, stack = TRUE)
+          }
         }
       }
-
-
-
     }
   }
   openxlsx::saveWorkbook(wb, filename, overwrite = TRUE)

--- a/R/significance.R
+++ b/R/significance.R
@@ -61,7 +61,6 @@
   names(mat_df)[(ncol(display_keys) + 1):ncol(mat_df)] <- column_labels
 
   if (length(group_vars) > 0) {
-    attr(mat_df, "_merge_reference") <- display_keys[group_vars]
     for (grp in group_vars) {
       grp_values <- mat_df[[grp]]
       if (length(grp_values) > 1) {

--- a/R/significance.R
+++ b/R/significance.R
@@ -61,6 +61,7 @@
   names(mat_df)[(ncol(display_keys) + 1):ncol(mat_df)] <- column_labels
 
   if (length(group_vars) > 0) {
+    attr(mat_df, "_merge_reference") <- display_keys[group_vars]
     for (grp in group_vars) {
       grp_values <- mat_df[[grp]]
       if (length(grp_values) > 1) {


### PR DESCRIPTION
## Summary
- enhance intra-year significance helper to keep descriptor columns and build multi-level labels for row and column headers
- propagate descriptor context when generating intra-year significance matrices so Excel tables show category information without duplicated suffixes

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68e90cdf7908832d9958719f439a632c