### PR TITLE
Add testthat scaffolding and expand obs survey tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dosr
 Type: Package
 Title: Herramientas para el Analisis de Encuestas del Observatorio Social
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: 
     person("Gabriel", "Sotomayor", , "gabrielsotomayorl@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-9889-9637"))
@@ -26,5 +26,8 @@ Imports:
     stringr,
     labelled,
     tibble
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 URL: https://github.com/GabrielSotomayorl/dosr
 BugReports: https://github.com/GabrielSotomayorl/dosr/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# dosr 0.2.5
+
+## MEJORAS
+
+*   Se configuró la infraestructura de pruebas automatizadas con `testthat` (edición 3) y se añadieron casos unitarios para `obs_media()` basados en datos sintéticos con variables tipo CASEN.
+*   Se reforzaron los datos sintéticos tipo CASEN para las pruebas automatizadas, incluyendo pesos lognormales truncados, PSUs anidadas en estratos, hogares multi-persona y variables de pobreza y hogar/persona.
+*   Se ampliaron las pruebas unitarias para `obs_media()` (escenarios de fiabilidad, multi-año y hogar vs persona) y se añadieron pruebas de `obs_prop()` con dos años.
+
 # dosr 0.2.4
 
 ## MEJORAS
@@ -110,7 +118,6 @@
 ## CORRECCIONES
 
 *   Se ha corregido el orden de las columnas en el `data.frame` que devuelven las funciones a R. Ahora la columna `nivel` aparece consistentemente antes que las variables de desagregación, coincidiendo con el formato de la hoja "Consolidado" en Excel.
-
 
 # dosr 0.1.1
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(dosr)
+
+test_check("dosr")

--- a/tests/testthat/helper-synthetic-casen.R
+++ b/tests/testthat/helper-synthetic-casen.R
@@ -1,0 +1,132 @@
+make_expr_weights <- function(n, seed, p01 = 13, p50 = 75, p99 = 391, sdlog = 0.9) {
+  set.seed(seed)
+  w <- stats::rlnorm(n, meanlog = 0, sdlog = sdlog)
+  w <- w / stats::median(w) * p50
+  stats::pmin(stats::pmax(w, p01), p99)
+}
+
+split_into_households <- function(members) {
+  sizes <- integer()
+  while (sum(sizes) < members) {
+    sizes <- c(sizes, sample(1:6, size = 1, prob = c(0.25, 0.25, 0.2, 0.15, 0.1, 0.05)))
+  }
+  overflow <- sum(sizes) - members
+  if (overflow > 0) {
+    sizes[length(sizes)] <- max(1, sizes[length(sizes)] - overflow)
+  }
+  sizes
+}
+
+make_svy_casen_synth <- function(n = 400, seed = 123, scenario = c("A", "B", "C"), year = NULL) {
+  scenario <- match.arg(scenario)
+  set.seed(seed)
+
+  n_strata <- 5
+  n_psu <- max(ceiling(n / 16), 10)
+
+  psu_tbl <- data.frame(
+    varunit = seq_len(n_psu),
+    varstrat = rep(seq_len(n_strata), length.out = n_psu)
+  )
+
+  psu_size <- pmin(pmax(stats::rpois(n_psu, lambda = 16), 2), 63)
+
+  household_blocks_list <- vector("list", length(psu_size))
+  for (idx in seq_along(psu_size)) {
+    members <- psu_size[idx]
+    sizes <- split_into_households(members)
+    hh_ids <- paste0("H", psu_tbl$varunit[idx], "_", seq_along(sizes))
+    household_blocks_list[[idx]] <- data.frame(
+      varunit = psu_tbl$varunit[idx],
+      varstrat = psu_tbl$varstrat[idx],
+      idhogar = rep(hh_ids, sizes),
+      tot_per_h = rep(sizes, sizes)
+    )
+  }
+
+  household_blocks <- dplyr::bind_rows(household_blocks_list)
+  if (nrow(household_blocks) > n) {
+    household_blocks <- household_blocks[seq_len(n), , drop = FALSE]
+  }
+
+  base <- household_blocks
+
+  base <- base %>%
+    dplyr::group_by(.data$idhogar) %>%
+    dplyr::mutate(
+      id_persona = paste0(.data$idhogar, "_", dplyr::row_number()),
+      pco1 = as.integer(dplyr::row_number() == 1)
+    ) %>%
+    dplyr::ungroup()
+
+  set.seed(seed + 2)
+  if (scenario == "C") {
+    sexo <- rep(1L, nrow(base))
+    idx2 <- sample(seq_len(nrow(base)), size = min(8L, nrow(base)))
+    sexo[idx2] <- 2L
+  } else {
+    sexo <- sample(c(1L, 2L), size = nrow(base), replace = TRUE)
+  }
+
+  set.seed(seed + 3)
+  area <- sample(c(1L, 2L), size = nrow(base), replace = TRUE)
+
+  p_na <- 0.000593
+  p1 <- 0.0230
+  p2 <- 0.0525
+  p3 <- 1 - (p1 + p2 + p_na)
+  pobreza_probs <- c(p1, p2, p3, p_na)
+  set.seed(seed + 4)
+  pobreza_raw <- sample(c(1, 2, 3, NA), size = nrow(base), replace = TRUE, prob = pobreza_probs)
+
+  p_base <- ifelse(area == 2, 0.12, 0.06)
+  p_year <- if (!is.null(year) && year == "2022") 0.03 else 0
+  p <- pmin(pmax(p_base + p_year, 0.001), 0.9)
+  set.seed(seed + 5)
+  pobreza_bin <- stats::rbinom(nrow(base), 1, p)
+
+  base_mean <- 500
+  mean_shift <- ifelse(sexo == 2, 5, 0)
+  year_shift <- if (is.null(year)) 0 else if (year == "2022") 20 else 0
+  sd_val <- switch(
+    scenario,
+    A = 8,
+    B = 1500,
+    C = 8
+  )
+  ytrabajocorh <- stats::rnorm(nrow(base), mean = base_mean + mean_shift + year_shift, sd = sd_val)
+
+  expr <- make_expr_weights(nrow(base), seed = seed + 1)
+
+  base <- base %>%
+    dplyr::mutate(
+      sexo = sexo,
+      area = area,
+      pco1 = pco1,
+      expr = expr,
+      ytrabajocorh = ytrabajocorh,
+      tot_per_h = tot_per_h,
+      pobreza = pobreza_raw,
+      pobreza_bin = pobreza_bin
+    )
+
+  design_person <- srvyr::as_survey_design(
+    base,
+    ids = varunit,
+    strata = varstrat,
+    weights = expr
+  )
+
+  design_hogar <- srvyr::as_survey_design(
+    dplyr::filter(base, .data$pco1 == 1),
+    ids = varunit,
+    strata = varstrat,
+    weights = expr
+  )
+
+  list(
+    data = base,
+    design_person = design_person,
+    design_hogar = design_hogar
+  )
+}

--- a/tests/testthat/helper-synthetic-casen.R
+++ b/tests/testthat/helper-synthetic-casen.R
@@ -2,7 +2,7 @@ make_expr_weights <- function(n, seed, p01 = 13, p50 = 75, p99 = 391, sdlog = 0.
   set.seed(seed)
   w <- stats::rlnorm(n, meanlog = 0, sdlog = sdlog)
   w <- w / stats::median(w) * p50
-  stats::pmin(stats::pmax(w, p01), p99)
+  base::pmin(base::pmax(w, p01), p99)
 }
 
 split_into_households <- function(members) {

--- a/tests/testthat/test-helper-synthetic-casen.R
+++ b/tests/testthat/test-helper-synthetic-casen.R
@@ -1,0 +1,5 @@
+test_that("make_expr_weights produce pesos en rango esperado", {
+  w <- make_expr_weights(1000, seed = 1)
+  expect_true(all(w >= 13))
+  expect_true(all(w <= 391))
+})

--- a/tests/testthat/test-obs_media.R
+++ b/tests/testthat/test-obs_media.R
@@ -1,0 +1,175 @@
+skip_if_not_installed("srvyr")
+skip_if_not_installed("survey")
+
+test_that("obs_media devuelve estructura esperada y calcula medias correctamente", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  synth <- make_svy_casen_synth(n = 800, seed = 123, scenario = "A", year = "2022")
+  design <- synth$design_person
+
+  res <- obs_media(
+    designs = list("2022" = design),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = TRUE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_s3_class(res, "data.frame")
+  expected_cols <- c(
+    "variable", "nivel", "sexo",
+    "media_2022", "se_2022", "cv_2022", "fiabilidad_2022"
+  )
+  expect_true(all(expected_cols %in% names(res)))
+
+  df_manual <- data.frame(
+    varunit = rep(1:10, each = 2),
+    varstrat = rep(1, 20),
+    expr = rep(1, 20),
+    sexo = rep(c(1, 2), times = 10),
+    ytrabajocorh = ifelse(rep(c(1, 2), times = 10) == 1, 100, 200)
+  )
+  design_manual <- srvyr::as_survey_design(
+    df_manual,
+    ids = varunit,
+    strata = varstrat,
+    weights = expr
+  )
+
+  res_manual <- obs_media(
+    designs = list(manual = design_manual),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  sexo_manual <- as.character(res_manual$sexo)
+  media_manual <- res_manual$media_manual[sexo_manual == "1" & res_manual$nivel == "sexo"]
+  expect_equal(media_manual, 100, tolerance = 1e-8)
+})
+
+test_that("obs_media etiqueta como Fiable cuando el CV es bajo", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  synth <- make_svy_casen_synth(n = 1200, seed = 42, scenario = "A", year = "2022")
+  design <- synth$design_person
+
+  res <- obs_media(
+    designs = list("2022" = design),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = TRUE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_true(any(res$fiabilidad_2022 == "Fiable")) # TODO: endurecer cuando los umbrales sean configurables.
+})
+
+test_that("obs_media detecta fiabilidad baja por CV alto o n reducido", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  synth_b <- make_svy_casen_synth(n = 1000, seed = 321, scenario = "B", year = "2022")
+  design_b <- synth_b$design_person
+
+  res_b <- obs_media(
+    designs = list("2022" = design_b),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = TRUE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_true(any(res_b$fiabilidad_2022 %in% c("No Fiable", "Poco Fiable")))
+
+  synth_c <- make_svy_casen_synth(n = 160, seed = 456, scenario = "C", year = "2022")
+  design_c <- synth_c$design_person
+
+  res_c <- obs_media(
+    designs = list("2022" = design_c),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = TRUE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  sexo_c <- as.character(res_c$sexo)
+  fiab_baja <- res_c$fiabilidad_2022[sexo_c == "2" & res_c$nivel == "sexo"]
+  expect_true(any(fiab_baja %in% c("No Fiable", "Sin casos", "Poco Fiable")))
+})
+
+test_that("obs_media maneja diferencias hogar vs persona con diseños filtrados", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  synth <- make_svy_casen_synth(n = 900, seed = 10, scenario = "A", year = "2022")
+  design_person <- synth$design_person
+  design_hogar <- synth$design_hogar
+
+  res_persona <- obs_media(
+    designs = list("2022" = design_person),
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = FALSE,
+    multi_des = FALSE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  res_hogar <- obs_media(
+    designs = list("2022" = design_hogar),
+    var = "tot_per_h",
+    des = "area",
+    sig = FALSE,
+    multi_des = FALSE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_s3_class(res_hogar, "data.frame")
+  expect_lt(nrow(design_hogar$variables), nrow(design_person$variables))
+  expect_true(all(c("media_2022", "fiabilidad_2022") %in% names(res_hogar)))
+})
+
+test_that("obs_media combina múltiples años y genera columnas por sufijo", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  s2020 <- make_svy_casen_synth(n = 1000, seed = 11, scenario = "A", year = "2020")
+  s2022 <- make_svy_casen_synth(n = 1000, seed = 12, scenario = "A", year = "2022")
+
+  designs <- list("2020" = s2020$design_person, "2022" = s2022$design_person)
+
+  res_multi <- obs_media(
+    designs = designs,
+    var = "ytrabajocorh",
+    des = "sexo",
+    sig = TRUE,
+    multi_des = TRUE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_true(all(c("media_2020", "media_2022", "fiabilidad_2020", "fiabilidad_2022") %in% names(res_multi)))
+  expect_true(nrow(res_multi) > 0)
+})

--- a/tests/testthat/test-obs_prop.R
+++ b/tests/testthat/test-obs_prop.R
@@ -1,0 +1,33 @@
+skip_if_not_installed("srvyr")
+skip_if_not_installed("survey")
+
+test_that("obs_prop estructura básica y columnas por año", {
+  old_opts <- options(survey.lonely.psu = "adjust")
+  on.exit(options(old_opts), add = TRUE)
+
+  s2020 <- make_svy_casen_synth(n = 1000, seed = 201, scenario = "A", year = "2020")
+  s2022 <- make_svy_casen_synth(n = 1000, seed = 202, scenario = "A", year = "2022")
+
+  designs <- list("2020" = s2020$design_person, "2022" = s2022$design_person)
+
+  res <- obs_prop(
+    designs = designs,
+    var = "pobreza_bin",
+    des = "area",
+    sig = TRUE,
+    multi_des = FALSE,
+    parallel = FALSE,
+    save_xlsx = FALSE,
+    verbose = FALSE
+  )
+
+  expect_s3_class(res, "data.frame")
+  expected_cols <- c(
+    "pobreza_bin", "nivel", "area",
+    "prop_2020", "prop_2022",
+    "fiabilidad_2020", "fiabilidad_2022"
+  )
+  expect_true(all(expected_cols %in% names(res)))
+  diffs <- res$prop_2020 - res$prop_2022
+  expect_true(any(!is.na(diffs) & diffs != 0))
+})


### PR DESCRIPTION
## Summary
- keep package version at 0.2.5 while extending NEWS with synthetic CASEN-style testing improvements
- simplify the synthetic survey helper (no purrr), add deterministic year/poverty effects, and return persona/hogar designs
- stabilize obs_media/obs_prop tests with robust filtering, deterministic fiabilidad cases, and household/persona coverage

## Testing
- ⚠️ `R -q -e "testthat::test_local()"` *(failed: R executable is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9d410750832d9547f55e71556493)